### PR TITLE
fix: remove MDI font import to prevent bundle bloat

### DIFF
--- a/dev/serve.js
+++ b/dev/serve.js
@@ -1,6 +1,7 @@
 import Serve from './serve.vue'
 import vuetify from '../src/plugins/vuetify'
 import 'vuetify/dist/vuetify.min.css'
+import '@mdi/font/css/materialdesignicons.css'
 import { createApp } from 'vue'
 
 function registerPlugins(app) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
       "name": "@innovation-system/vuetify-week-scheduler-v3",
       "version": "0.1.6",
       "license": "MIT",
-      "dependencies": {
-        "vue": "^3.0.0",
-        "vuetify": "^3.0.0"
-      },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@mdi/font": "^7.4.47",
@@ -2433,6 +2429,7 @@
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
       "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/shared": "3.5.13"
       }
@@ -2442,6 +2439,7 @@
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
       "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.5.13",
         "@vue/shared": "3.5.13"
@@ -2452,6 +2450,7 @@
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
       "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.5.13",
         "@vue/runtime-core": "3.5.13",
@@ -2464,6 +2463,7 @@
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
       "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.13",
         "@vue/shared": "3.5.13"
@@ -3278,7 +3278,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -7341,6 +7342,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
       "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.13",
         "@vue/compiler-sfc": "3.5.13",
@@ -7387,6 +7389,7 @@
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.8.2.tgz",
       "integrity": "sha512-UJNFP4egmKJTQ3V3MKOq+7vIUKO7/Fko5G6yUsOW2Rm0VNBvAjgO6VY6EnK3DTqEKN6ugVXDEPw37NQSTGLZvw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20 || >=14.13"
       },

--- a/package.json
+++ b/package.json
@@ -36,10 +36,6 @@
     "format": "prettier --write src/",
     "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it"
   },
-  "dependencies": {
-    "vue": "^3.0.0",
-    "vuetify": "^3.0.0"
-  },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
     "@mdi/font": "^7.4.47",

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -1,4 +1,3 @@
-import '@mdi/font/css/materialdesignicons.css' // Ensure you are using css-loader
 import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components' // TODO: import only used components?
 import * as directives from 'vuetify/directives' // TODO: import only used directives? unable to resolve this paths


### PR DESCRIPTION
## Problem

The `@mdi/font` CSS import in `src/plugins/vuetify.js` causes severe bundle size issues when this library is used in production applications with code-splitting:

- Creates a **6.88 MB** CSS chunk containing base64-encoded MDI fonts
- Causes duplicate font loading when the consuming application already imports `@mdi/font`
- Increases build time and complexity
- Forces all MDI fonts to be cached in service workers (exceeding default PWA cache limits)

Additionally, `vue` and `vuetify` were incorrectly listed in both `dependencies` and `peerDependencies`, which could cause them to be bundled with the library.

## Root Cause

```javascript
import '@mdi/font/css/materialdesignicons.css'; // ❌ This line in src/plugins/vuetify.js
```

When Vite code-splits the scheduler component, it bundles the entire MDI font CSS (with ~7 MB of base64 fonts) into a separate chunk file.

Also, having dependencies in both `dependencies` and `peerDependencies` is incorrect for a component library - they should only be in `peerDependencies`.

## Solution

Remove the MDI font import from the library source and let consuming applications handle font loading themselves. Also fix the package.json dependency structure. This is the proper pattern for component libraries.

**Changes made:**

1. ✅ Removed `import '@mdi/font/css/materialdesignicons.css'` from `src/plugins/vuetify.js`
2. ✅ Added `import '@mdi/font/css/materialdesignicons.css'` to `dev/serve.js` (playground/demo needs it)
3. ✅ Removed `vue` and `vuetify` from `dependencies` (kept only in `peerDependencies`)

**Why this works:**
- Vuetify 3 uses SVG icons by default with `defaultSet: 'mdi'`
- Icon names like `mdi-close` are just string identifiers, not font references
- The library works fine without bundling the font CSS
- Consuming applications import the font CSS in their own setup
- Component libraries should not bundle peer dependencies

**Before:**
```javascript
// src/plugins/vuetify.js (LIBRARY)
import '@mdi/font/css/materialdesignicons.css'; // ❌ Library bundles fonts
import { createVuetify } from 'vuetify';
```

```json
// package.json
{
  "dependencies": {
    "vue": "^3.0.0",      // ❌ Should not be in dependencies
    "vuetify": "^3.0.0"   // ❌ Should not be in dependencies
  },
  "peerDependencies": {
    "vue": "^3.0.0",
    "vuetify": "^3.0.0"
  }
}
```

**After:**
```javascript
// src/plugins/vuetify.js (LIBRARY)
import { createVuetify } from 'vuetify'; // ✅ No font import

// dev/serve.js (PLAYGROUND - acts as consuming app)
import '@mdi/font/css/materialdesignicons.css'; // ✅ Playground imports fonts

// Consumer's app (e.g., on-board)
import '@mdi/font/css/materialdesignicons.css'; // ✅ Consumer imports fonts
```

```json
// package.json
{
  // ✅ No dependencies section - peer dependencies only
  "peerDependencies": {
    "@mdi/font": "^5.0.0 || ^6.0.0 || ^7.0.0",
    "vue": "^3.0.0",
    "vuetify": "^3.0.0"
  }
}
```

## Benefits

✅ Reduces library bundle size by ~7 MB when code-split  
✅ Prevents duplicate font loading  
✅ Prevents bundling Vue and Vuetify with the library  
✅ Gives consumers control over font loading strategy  
✅ Fixes PWA service worker cache size issues  
✅ Faster build times  
✅ Proper separation of concerns (library vs. app responsibilities)  
✅ Correct dependency structure for component libraries

## Migration Guide

Consuming applications need to ensure they import MDI fonts in their own setup:

```javascript
// In consuming app's main entry point or plugins/vuetify.js
import '@mdi/font/css/materialdesignicons.css';
```

Most applications using Vuetify already have this import, so **no changes needed** for existing consumers.

## Related

This fix mirrors the changes in [vuetify-base-table PR #29](https://github.com/innovation-system/vuetify-base-table/pull/29)