### PR TITLE
fix: improve touch period editing

### DIFF
--- a/src/vuetify-week-scheduler-period.vue
+++ b/src/vuetify-week-scheduler-period.vue
@@ -12,14 +12,17 @@
         height: period.height + 'px',
       }"
       v-bind="props"
-      @mousedown.stop="$emit('period-drag', $event)"
-      @touchstart.stop="$emit('period-drag', $event)"
-      @contextmenu.stop.prevent="$emit('edit', $event)"
-      @dblclick.stop.prevent="$emit('edit', $event)"
+      @mousedown.stop="onPeriodDown"
+      @touchstart.stop="onPeriodTouchStart"
+      @touchmove="onPeriodTouchMove"
+      @touchend="clearLongPress"
+      @touchcancel="clearLongPress"
+      @contextmenu.stop.prevent="onEdit"
+      @dblclick.stop.prevent="onEdit"
     >
       <div class="vws-period-container">
         <v-icon
-          v-show="editable && isHovering"
+          v-show="showControls(isHovering)"
           size="small"
           class="vws-handle"
           @mousedown.stop="onPeriodResize($event, true)"
@@ -34,7 +37,7 @@
         <div v-show="!shortPeriod" class="vws-period-title text-truncate">
           {{ options.title }}
         </div>
-        <div v-show="editable && isHovering" class="vws-period-buttons" justify="end">
+        <div v-show="showControls(isHovering)" class="vws-period-buttons" justify="end">
           <v-btn
             class="mx-1 mt-1"
             icon="mdi-close"
@@ -61,7 +64,7 @@
           </v-btn>
         </div>
         <v-icon
-          v-show="editable && isHovering"
+          v-show="showControls(isHovering)"
           size="small"
           class="vws-handle"
           style="bottom: 0"
@@ -90,12 +93,22 @@ export default {
       default: () => ({}),
     },
     editable: { type: Boolean, default: false },
+    controlsVisible: { type: Boolean, default: false },
   },
-  emits: ['edit', 'delete', 'clone', 'period-drag', 'period-resize'],
+  emits: ['edit', 'delete', 'clone', 'period-drag', 'period-resize', 'show-controls'],
   setup() {
     // this is needed to get the correct HTML element reference
     const root = ref(null)
     return { root }
+  },
+  data() {
+    return {
+      longPressTimer: null,
+      longPressStart: null,
+      longPressDelay: 500,
+      longPressMoveThreshold: 8,
+      supportsHover: false,
+    }
   },
   computed: {
     options() {
@@ -105,7 +118,86 @@ export default {
       return this.period.height <= 30
     },
   },
+  mounted() {
+    this.supportsHover = window.matchMedia?.('(hover: hover) and (pointer: fine)').matches ?? true
+  },
+  beforeUnmount() {
+    this.clearLongPress()
+  },
   methods: {
+    onPeriodDown(e) {
+      this.clearLongPress()
+      this.$emit('period-drag', e)
+    },
+    onPeriodTouchStart(e) {
+      this.$emit('show-controls')
+      this.clearLongPress()
+
+      const touch = this.getTouch(e)
+      if (touch) {
+        this.longPressStart = {
+          x: touch.clientX,
+          y: touch.clientY,
+        }
+
+        this.longPressTimer = setTimeout(() => {
+          const start = this.longPressStart
+          this.longPressTimer = null
+          this.longPressStart = null
+
+          if (start) {
+            e.preventDefault()
+            this.$emit('edit', this.createTouchEditEvent(e, start))
+          }
+        }, this.longPressDelay)
+      }
+
+      e.preventDefault()
+      this.$emit('period-drag', e)
+    },
+    onPeriodTouchMove(e) {
+      if (!this.longPressTimer || !this.longPressStart) return
+
+      const touch = this.getTouch(e)
+      if (!touch) {
+        this.clearLongPress()
+        return
+      }
+
+      const dx = Math.abs(touch.clientX - this.longPressStart.x)
+      const dy = Math.abs(touch.clientY - this.longPressStart.y)
+
+      if (dx > this.longPressMoveThreshold || dy > this.longPressMoveThreshold) {
+        this.clearLongPress()
+      }
+    },
+    clearLongPress() {
+      if (this.longPressTimer) {
+        clearTimeout(this.longPressTimer)
+        this.longPressTimer = null
+      }
+      this.longPressStart = null
+    },
+    onEdit(e) {
+      this.clearLongPress()
+      this.$emit('edit', e)
+    },
+    getTouch(e) {
+      return e.touches?.[0] || e.changedTouches?.[0]
+    },
+    createTouchEditEvent(originalEvent, position) {
+      return {
+        type: 'longpress',
+        clientX: position.x,
+        clientY: position.y,
+        originalEvent,
+        preventDefault: () => originalEvent.preventDefault(),
+        stopPropagation: () => originalEvent.stopPropagation(),
+      }
+    },
+    showControls(isHovering) {
+      return this.editable && (this.controlsVisible || (this.supportsHover && isHovering))
+    },
     onPeriodResize(e, isUp) {
       this.$emit('period-resize', {
         $event: e,

--- a/src/vuetify-week-scheduler-period.vue
+++ b/src/vuetify-week-scheduler-period.vue
@@ -151,7 +151,6 @@ export default {
           this.longPressStart = null
 
           if (start) {
-            e.preventDefault()
             this.$emit('edit', this.createTouchEditEvent(e, start))
           }
         }, this.longPressDelay)
@@ -190,6 +189,7 @@ export default {
       return e.touches?.[0] || e.changedTouches?.[0]
     },
     isInteractiveTouchTarget(e) {
+      // Child controls already stop touchstart; keep this as a defensive backstop.
       return Boolean(
         e.target?.closest?.(
           '.vws-period-buttons, .vws-handle, button, a, input, textarea, select, [role="button"]',
@@ -202,8 +202,6 @@ export default {
         clientX: position.x,
         clientY: position.y,
         originalEvent,
-        preventDefault: () => originalEvent.preventDefault(),
-        stopPropagation: () => originalEvent.stopPropagation(),
       }
     },
     showControls(isHovering) {

--- a/src/vuetify-week-scheduler-period.vue
+++ b/src/vuetify-week-scheduler-period.vue
@@ -130,6 +130,11 @@ export default {
       this.$emit('period-drag', e)
     },
     onPeriodTouchStart(e) {
+      if (this.isInteractiveTouchTarget(e)) {
+        this.clearLongPress()
+        return
+      }
+
       this.$emit('show-controls')
       this.clearLongPress()
 
@@ -152,7 +157,6 @@ export default {
         }, this.longPressDelay)
       }
 
-      e.preventDefault()
       this.$emit('period-drag', e)
     },
     onPeriodTouchMove(e) {
@@ -184,6 +188,13 @@ export default {
     },
     getTouch(e) {
       return e.touches?.[0] || e.changedTouches?.[0]
+    },
+    isInteractiveTouchTarget(e) {
+      return Boolean(
+        e.target?.closest?.(
+          '.vws-period-buttons, .vws-handle, button, a, input, textarea, select, [role="button"]',
+        ),
+      )
     },
     createTouchEditEvent(originalEvent, position) {
       return {

--- a/src/vuetify-week-scheduler.vue
+++ b/src/vuetify-week-scheduler.vue
@@ -250,7 +250,6 @@ export default {
     /** When clicking on a day */
     onDayDown(day, e) {
       if (!this.editable) return
-      if (this.closeEditMenuIfOpen(e)) return
 
       this.clearPeriodControls()
 
@@ -384,7 +383,6 @@ export default {
     },
     onPeriodDown(e, day, index) {
       if (this.editable) {
-        if (this.closeEditMenuIfOpen(e)) return
         const el = e.currentTarget
         this.draggingPeriod = {
           el,
@@ -398,7 +396,6 @@ export default {
     onPeriodResize(event, day, index) {
       if (this.editable) {
         const { $event: e, isUp, $el } = event
-        if (this.closeEditMenuIfOpen(e)) return
 
         this.resizingPeriod = {
           el: $el,
@@ -697,14 +694,6 @@ export default {
       this.resizingPeriod = null
       this.clearPeriodControls()
     },
-    closeEditMenuIfOpen(e) {
-      if (!this.showEditMenu) return false
-
-      e?.preventDefault?.()
-      e?.stopPropagation?.()
-      this.closeEditMenu()
-      return true
-    },
     async editPeriod(day, index, e) {
       if (this.editable) {
         this.draggingPeriod = null
@@ -726,7 +715,7 @@ export default {
       }
     },
     getClientPosition(e) {
-      const touch = e?.touches?.[0] || e?.changedTouches?.[0]
+      const touch = this.getTouchPoint(e)
       if (touch) {
         return { x: touch.clientX, y: touch.clientY }
       }
@@ -735,6 +724,9 @@ export default {
         x: e?.clientX ?? 0,
         y: e?.clientY ?? 0,
       }
+    },
+    getTouchPoint(e) {
+      return e?.touches?.[0] || e?.changedTouches?.[0] || null
     },
     getY(e, prevent) {
       let y = null
@@ -747,7 +739,7 @@ export default {
         if (prevent) {
           e.preventDefault()
         }
-        const touch = e.touches[0] || e.changedTouches[0]
+        const touch = this.getTouchPoint(e)
         y = touch.clientY
       } else if (
         e.type === 'mousedown' ||

--- a/src/vuetify-week-scheduler.vue
+++ b/src/vuetify-week-scheduler.vue
@@ -16,6 +16,8 @@
                 :period="p"
                 :settings="settings"
                 :editable="editable"
+                :controls-visible="isPeriodControlsVisible(day.day, p.index)"
+                @show-controls="showPeriodControls(day.day, p.index)"
                 @period-drag="onPeriodDown($event, day.day, p.index)"
                 @period-resize="onPeriodResize($event, day.day, p.index)"
                 @delete="deletePeriod(day.day, p.index)"
@@ -40,6 +42,13 @@
         </tr>
       </tbody>
     </table>
+    <div
+      v-if="showEditMenu"
+      class="vws-edit-click-blocker"
+      @mousedown.stop.prevent="closeEditMenu"
+      @touchstart.stop.prevent="closeEditMenu"
+      @click.stop.prevent="closeEditMenu"
+    ></div>
     <div class="vws-grid">
       <div class="vws-grid-head">
         <div v-for="n in settings.days" :key="n" class="vws-grid-day">
@@ -150,6 +159,7 @@ export default {
       newPeriod: null,
       draggingPeriod: null,
       resizingPeriod: null,
+      activeControlsPeriod: null,
       showEditMenu: false,
       x: 0,
       y: 0,
@@ -240,6 +250,9 @@ export default {
     /** When clicking on a day */
     onDayDown(day, e) {
       if (!this.editable) return
+      if (this.closeEditMenuIfOpen(e)) return
+
+      this.clearPeriodControls()
 
       const rect = e.currentTarget.getBoundingClientRect()
       const offset = this.getY(e, true) - rect.top
@@ -272,6 +285,15 @@ export default {
         textColor: this.settings.periodTextColor,
         ...period,
       }
+    },
+    showPeriodControls(day, index) {
+      this.activeControlsPeriod = { day, index }
+    },
+    clearPeriodControls() {
+      this.activeControlsPeriod = null
+    },
+    isPeriodControlsVisible(day, index) {
+      return this.activeControlsPeriod?.day === day && this.activeControlsPeriod?.index === index
     },
     handleEvents() {
       const onUp = () => {
@@ -362,6 +384,7 @@ export default {
     },
     onPeriodDown(e, day, index) {
       if (this.editable) {
+        if (this.closeEditMenuIfOpen(e)) return
         const el = e.currentTarget
         this.draggingPeriod = {
           el,
@@ -375,6 +398,7 @@ export default {
     onPeriodResize(event, day, index) {
       if (this.editable) {
         const { $event: e, isUp, $el } = event
+        if (this.closeEditMenuIfOpen(e)) return
 
         this.resizingPeriod = {
           el: $el,
@@ -428,9 +452,11 @@ export default {
       }
     },
     deletePeriod(day, index) {
+      this.clearPeriodControls()
       this.data[day].periods.splice(index, 1)
     },
     clonePeriod(day, indexOrPeriod) {
+      this.clearPeriodControls()
       const period =
         typeof indexOrPeriod === 'object' ? indexOrPeriod : this.data[day].periods[indexOrPeriod]
       for (const d of this.data) {
@@ -664,20 +690,50 @@ export default {
 
       element.addEventListener(event, callback, options)
     },
+    closeEditMenu() {
+      this.showEditMenu = false
+      this.newPeriod = null
+      this.draggingPeriod = null
+      this.resizingPeriod = null
+      this.clearPeriodControls()
+    },
+    closeEditMenuIfOpen(e) {
+      if (!this.showEditMenu) return false
+
+      e?.preventDefault?.()
+      e?.stopPropagation?.()
+      this.closeEditMenu()
+      return true
+    },
     async editPeriod(day, index, e) {
       if (this.editable) {
+        this.draggingPeriod = null
+        this.clearPeriodControls()
+
         if (this.$attrs.onEdit) {
           this.$emit('edit', { day, index })
         } else {
-          e.preventDefault()
+          e?.preventDefault?.()
+          const { x, y } = this.getClientPosition(e)
           this.showEditMenu = false
-          this.x = e.clientX
-          this.y = e.clientY
+          this.x = x
+          this.y = y
           const { periods } = this.modelValue[day]
           this.editEvent = periods[index]
           await this.$nextTick()
           this.showEditMenu = true
         }
+      }
+    },
+    getClientPosition(e) {
+      const touch = e?.touches?.[0] || e?.changedTouches?.[0]
+      if (touch) {
+        return { x: touch.clientX, y: touch.clientY }
+      }
+
+      return {
+        x: e?.clientX ?? 0,
+        y: e?.clientY ?? 0,
       }
     },
     getY(e, prevent) {
@@ -776,6 +832,11 @@ export default {
   width: 14.28571%;
   border-left: 1px solid #ccc;
   border-right: 1px solid #ccc;
+}
+.vws-edit-click-blocker {
+  position: absolute;
+  inset: 0;
+  z-index: 9;
 }
 .vws-grid {
   position: absolute;
@@ -893,6 +954,7 @@ export default {
   cursor: pointer;
   border-radius: 5px;
   touch-action: none;
+  -webkit-touch-callout: none;
   outline: 1px solid #ccc;
 }
 


### PR DESCRIPTION
## Summary

Fixes touch-device editing for scheduler periods, especially iOS Safari where `contextmenu` and `dblclick` are not reliable touch edit triggers.

## Changes

- Add long-press period editing with movement cancellation so touch drag and press-to-edit can coexist.
- Normalize edit menu coordinates for mouse, touch, and synthesized long-press events.
- Make period controls usable on touch devices while ensuring only one period shows controls at a time.
- Prevent scheduler interactions from creating or changing periods when the edit menu is open; outside taps inside the scheduler now close the menu only.
- Avoid sticky mobile hover keeping period controls visible after delete/copy/edit interactions.

## Root Cause

The edit path was only wired to desktop-oriented events, and touch interactions depended on hover state that can become sticky on mobile. VMenu outside-click behavior also allowed the underlying scheduler touch handlers to run after closing the menu.

## Validation

- `npm exec eslint -- src/vuetify-week-scheduler-period.vue src/vuetify-week-scheduler.vue vite.config.js`
- `npm run build`
- `git diff --check`
- Manual phone testing through Tailscale Funnel during development

Fixes #4
